### PR TITLE
Bugfix: number_format had incorrect parameters

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -149,7 +149,7 @@ class Currency
 		'TOP' => ['code' => 'TOP', 'title' => 'Tonga, Paanga', 'symbol' => null, 'precision' => 2, 'thousandSeparator' => '.', 'decimalSeparator' => ',', 'symbolPlacement' => 'before'],
 		'AED' => ['code' => 'AED', 'title' => 'UAE Dirham', 'symbol' => null, 'precision' => 2, 'thousandSeparator' => '.', 'decimalSeparator' => ',', 'symbolPlacement' => 'before'],
 		'UAH' => ['code' => 'UAH', 'title' => 'Ukraine, Hryvnia', 'symbol' => null, 'precision' => 2, 'thousandSeparator' => ',', 'decimalSeparator' => ' ', 'symbolPlacement' => 'before'],
-		'USD' => ['code' => 'USD', 'title' => 'US Dollar', 'symbol' => '$', 'precision' => 2, 'thousandSeparator' => '.', 'decimalSeparator' => ',', 'symbolPlacement' => 'before'],
+		'USD' => ['code' => 'USD', 'title' => 'US Dollar', 'symbol' => '$', 'precision' => 2, 'thousandSeparator' => ',', 'decimalSeparator' => '.', 'symbolPlacement' => 'before'],
 		'VUV' => ['code' => 'VUV', 'title' => 'Vanuatu, Vatu', 'symbol' => null, 'precision' => 0, 'thousandSeparator' => '', 'decimalSeparator' => ',', 'symbolPlacement' => 'before'],
 		'VEF' => ['code' => 'VEF', 'title' => 'Venezuela Bolivares Fuertes', 'symbol' => null, 'precision' => 2, 'thousandSeparator' => ',', 'decimalSeparator' => '.', 'symbolPlacement' => 'before'],
 		'VEB' => ['code' => 'VEB', 'title' => 'Venezuela, Bolivar', 'symbol' => null, 'precision' => 2, 'thousandSeparator' => ',', 'decimalSeparator' => '.', 'symbolPlacement' => 'before'],

--- a/src/Money.php
+++ b/src/Money.php
@@ -98,8 +98,8 @@ class Money
 		return number_format(
 			$this->amount,
 			$this->currency->getPrecision(),
-			$this->currency->getThousandSeparator(),
-			$this->currency->getDecimalSeparator()
+			$this->currency->getDecimalSeparator(),
+			$this->currency->getThousandSeparator()
 		);
 	}
 }


### PR DESCRIPTION
- bugfix 1: USD has decimal and thousands seperators switched.
- bugfix 2: `number_format` had argument order of decimal and thoursands switches
  - http://php.net/manual/en/function.number-format.php

Since both USD and number_format had their thousands/decimals switched, the rest of the data here might be incorrect also: https://github.com/gerardojbaez/money/blob/4b817eb238d42c95904ff9d5709f020e6ba9d130/src/Currency.php#L67
