### PR TITLE
Fix symbol placement for euros

### DIFF
--- a/src/Currency.php
+++ b/src/Currency.php
@@ -351,7 +351,7 @@ class Currency
             'precision' => 2,
             'thousandSeparator' => '.',
             'decimalSeparator' => ',',
-            'symbolPlacement' => 'after'
+            'symbolPlacement' => 'before'
         ],
         'GHC' => [
             'code' => 'GHC',

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -347,7 +347,7 @@ class Currency
         'EUR' => [
             'code' => 'EUR',
             'title' => 'Euro',
-            'symbol' => ' €',
+            'symbol' => '€ ',
             'precision' => 2,
             'thousandSeparator' => '.',
             'decimalSeparator' => ',',


### PR DESCRIPTION
I'm from Europe, we place the symbol before the amount, like this:

```
€ 1.234.567,89
```